### PR TITLE
Make paths to assets more portable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ FetchContent_MakeAvailable(stb)
 FetchContent_Declare(assimp GIT_REPOSITORY https://github.com/assimp/assimp.git)
 FetchContent_MakeAvailable(assimp)
 
+cmake_path(SET DATA_DIR "${PROJECT_SOURCE_DIR}")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/data_dir.h.in" "${CMAKE_CURRENT_BINARY_DIR}/src/data_dir.h")
+
 add_executable(mygame main.cpp
         src/shaders/shader.h
         src/stbimage/stb.cpp
@@ -84,7 +87,7 @@ add_executable(mygame main.cpp
         src/utils/Log.cpp
 )
 
-target_include_directories(mygame PRIVATE ${stb_SOURCE_DIR} )
+target_include_directories(mygame PRIVATE ${stb_SOURCE_DIR} "${CMAKE_CURRENT_BINARY_DIR}/src")
 
 target_link_libraries(mygame glfw glm::glm freetype glad assimp)
 

--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,7 @@
 #include "src/terrain/Terrain.h"
 #include "src/terrain/TerrainRenderer.h"
 #include "src/text/TextRenderer.h"
+#include <data_dir.h>
 
 using path = std::filesystem::path;
 
@@ -51,14 +52,14 @@ int main() {
     SkyboxRenderer skyboxRenderer(camera);
     Skybox skybox("cloudy");
     Terrain terrain(
-        path("/Users/vladino/CLionProjects/mygame/resources/images/heightmaps/heightmap.png"),
-        path("/Users/vladino/CLionProjects/mygame/resources/images/blendMap4.png")
+        data_dir() /= path("resources/images/heightmaps/heightmap.png"),
+        data_dir() /= path("resources/images/blendMap4.png")
     );
     Fps fps;
 
     // Player related code
     // -------------------
-    Model wolf(path("/Users/vladino/CLionProjects/mygame/resources/objects/animals/wolf2/Wolf_One_obj.obj"));
+    Model wolf(data_dir() /= path("resources/objects/animals/wolf2/Wolf_One_obj.obj"));
     Player player(
         camera,
         terrain,

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <filesystem>
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>
@@ -16,6 +17,8 @@
 #include "src/terrain/Terrain.h"
 #include "src/terrain/TerrainRenderer.h"
 #include "src/text/TextRenderer.h"
+
+using path = std::filesystem::path;
 
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 GLFWwindow* createAndConfigureWindow();
@@ -48,14 +51,14 @@ int main() {
     SkyboxRenderer skyboxRenderer(camera);
     Skybox skybox("cloudy");
     Terrain terrain(
-        "/Users/vladino/CLionProjects/mygame/resources/images/heightmaps/heightmap.png",
-        "/Users/vladino/CLionProjects/mygame/resources/images/blendMap4.png"
+        path("/Users/vladino/CLionProjects/mygame/resources/images/heightmaps/heightmap.png"),
+        path("/Users/vladino/CLionProjects/mygame/resources/images/blendMap4.png")
     );
     Fps fps;
 
     // Player related code
     // -------------------
-    Model wolf("/Users/vladino/CLionProjects/mygame/resources/objects/animals/wolf2/Wolf_One_obj.obj");
+    Model wolf(path("/Users/vladino/CLionProjects/mygame/resources/objects/animals/wolf2/Wolf_One_obj.obj"));
     Player player(
         camera,
         terrain,

--- a/src/data_dir.h.in
+++ b/src/data_dir.h.in
@@ -1,0 +1,13 @@
+#ifndef DATA_DIR_H
+#define DATA_DIR_H
+
+#include <filesystem>
+
+inline
+std::filesystem::path
+data_dir()
+{
+	return std::filesystem::path("${DATA_DIR}");
+}
+
+#endif

--- a/src/images/Image.cpp
+++ b/src/images/Image.cpp
@@ -5,8 +5,9 @@
 
 #include "../utils/Log.h"
 
-Image::Image(char const* path) {
-    data = stbi_load(path, &width, &height, &nrChannels, 0);
+Image::Image(const std::filesystem::path& path) {
+    data = stbi_load(path.c_str(), &width, &height, &nrChannels, 0);
+
     if (!data) {
         std::cerr << "Failed to load image: " << path << std::endl;
     }

--- a/src/images/Image.h
+++ b/src/images/Image.h
@@ -1,6 +1,7 @@
 #ifndef IMAGE_H
 #define IMAGE_H
 
+#include <filesystem>
 
 
 class Image {
@@ -8,7 +9,7 @@ private:
     unsigned char* data;
     int width, height, nrChannels;
 public:
-    explicit Image(char const* path);
+    explicit Image(const std::filesystem::path& path);
     ~Image() = default;
     float getGrayscaleValue(int x, int y) const;
     bool isBlackColor(int x, int y) const;

--- a/src/models/EntityRenderer.cpp
+++ b/src/models/EntityRenderer.cpp
@@ -2,17 +2,20 @@
 
 #include "EntityRenderer.h"
 
+#include <filesystem>
 #include "../objects/Entity.h"
+
+using path = std::filesystem::path;
 
 EntityRenderer::EntityRenderer(Camera* camera) {
     this->camera = camera;
     this->singleInstanceShader = new Shader(
-        "/Users/vladino/CLionProjects/mygame/src/shaders/files/singleInstanceShader.vs",
-        "/Users/vladino/CLionProjects/mygame/src/shaders/files/modelShader.fs"
+        path("/Users/vladino/CLionProjects/mygame/src/shaders/files/singleInstanceShader.vs"),
+        path("/Users/vladino/CLionProjects/mygame/src/shaders/files/modelShader.fs")
     );
     this->multiInstanceShader = new Shader(
-        "/Users/vladino/CLionProjects/mygame/src/shaders/files/multiInstanceShader.vs",
-        "/Users/vladino/CLionProjects/mygame/src/shaders/files/modelShader.fs"
+        path("/Users/vladino/CLionProjects/mygame/src/shaders/files/multiInstanceShader.vs"),
+        path("/Users/vladino/CLionProjects/mygame/src/shaders/files/modelShader.fs")
     );
 }
 

--- a/src/models/EntityRenderer.cpp
+++ b/src/models/EntityRenderer.cpp
@@ -4,18 +4,19 @@
 
 #include <filesystem>
 #include "../objects/Entity.h"
+#include <data_dir.h>
 
 using path = std::filesystem::path;
 
 EntityRenderer::EntityRenderer(Camera* camera) {
     this->camera = camera;
     this->singleInstanceShader = new Shader(
-        path("/Users/vladino/CLionProjects/mygame/src/shaders/files/singleInstanceShader.vs"),
-        path("/Users/vladino/CLionProjects/mygame/src/shaders/files/modelShader.fs")
+        data_dir() /= path("src/shaders/files/singleInstanceShader.vs"),
+        data_dir() /= path("src/shaders/files/modelShader.fs")
     );
     this->multiInstanceShader = new Shader(
-        path("/Users/vladino/CLionProjects/mygame/src/shaders/files/multiInstanceShader.vs"),
-        path("/Users/vladino/CLionProjects/mygame/src/shaders/files/modelShader.fs")
+        data_dir() /= path("src/shaders/files/multiInstanceShader.vs"),
+        data_dir() /= path("src/shaders/files/modelShader.fs")
     );
 }
 

--- a/src/models/Mesh.h
+++ b/src/models/Mesh.h
@@ -2,6 +2,7 @@
 
 #ifndef MESH_H
 #define MESH_H
+#include <filesystem>
 #include "../shaders/shader.h"
 #include "glm/vec2.hpp"
 #include "glm/vec3.hpp"
@@ -16,7 +17,7 @@ struct Vertex {
 struct Texture {
     unsigned int id;
     std::string type;
-    std::string path;
+    std::filesystem::path path;
 };
 
 class Mesh {

--- a/src/models/Model.h
+++ b/src/models/Model.h
@@ -2,6 +2,7 @@
 
 #ifndef MODEL_H
 #define MODEL_H
+#include <filesystem>
 #include "Mesh.h"
 #include "../shaders/shader.h"
 #include "assimp/scene.h"
@@ -11,9 +12,9 @@
 class Model
 {
 public:
-    explicit Model(char *modelPath);
-    Model(char *modelPath, char *texturePath);
-    Model(char *modelPath, Texture *texture);
+    explicit Model(const std::filesystem::path& modelPath);
+    Model(const std::filesystem::path& modelPath, const std::filesystem::path& texturePath);
+    Model(const std::filesystem::path& modelPath, Texture *texture);
     explicit Model(Mesh &mesh);
 
     void Draw(Shader *shader) const;
@@ -22,13 +23,13 @@ public:
 private:
     std::vector<Mesh> meshes;
     std::vector<Texture> texturesLoaded;
-    std::string directory;
+    std::filesystem::path directory;
 
-    void loadModel(std::string path);
+    void loadModel(const std::filesystem::path& path);
     void processNode(aiNode *node, const aiScene *scene);
     Mesh processMesh(aiMesh *mesh, const aiScene *scene);
     std::vector<Texture> loadMaterialTextures(aiMaterial *mat, aiTextureType type, std::string typeName);
-    void loadSingleTexture(char *texturePath);
+    void loadSingleTexture(const std::filesystem::path& texturePath);
     void loadSingleTexture(Texture *texture);
 };
 

--- a/src/models/ModelGenerator.cpp
+++ b/src/models/ModelGenerator.cpp
@@ -5,7 +5,7 @@
 #include "Model.h"
 #include "../textures/TextureLoader.h"
 
-Model* ModelGenerator::generateCube(char *texturePath) {
+Model* ModelGenerator::generateCube(const std::filesystem::path& texturePath) {
  // Vertices for a cube
  float vertices[] = {
   // positions          // normals           // texture coords
@@ -85,7 +85,7 @@ Model* ModelGenerator::generateCube(char *texturePath) {
    return new Model(mesh);
 }
 
-Model* ModelGenerator::generateGrass(char *texturePath) {
+Model* ModelGenerator::generateGrass(const std::filesystem::path& texturePath) {
  float vertices[] = {
   // positions          // normals           // texture coords
   -0.5f, -0.5f, -0.5f,  0.0f,  0.0f, -1.0f,  0.0f,  0.0f,

--- a/src/models/ModelGenerator.h
+++ b/src/models/ModelGenerator.h
@@ -3,13 +3,14 @@
 #ifndef MODELGENERATOR_H
 #define MODELGENERATOR_H
 
+#include <filesystem>
 #include "Model.h"
 
 
 class ModelGenerator {
 public:
-    static Model* generateCube(char *texturePath);
-    static Model* generateGrass(char *texturePath);
+    static Model* generateCube(const std::filesystem::path& texturePath);
+    static Model* generateGrass(const std::filesystem::path& texturePath);
 };
 
 

--- a/src/objects/movers/PathPlayerMover.h
+++ b/src/objects/movers/PathPlayerMover.h
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include "../Player.h"
 #include "../../pathing/Path.h"
+#include <data_dir.h>
 
 
 class PathPlayerMover {
@@ -18,7 +19,7 @@ public:
         player(player), path(path) {
         path = Path(
             player.GetPosition(),
-            std::filesystem::path("/Users/vladino/CLionProjects/mygame/resources/images/route.png"),
+            data_dir() /= std::filesystem::path("resources/images/route.png"),
             terrainSize
         );
         // TODO: This may be NULL POINTER EXCEPTION

--- a/src/objects/movers/PathPlayerMover.h
+++ b/src/objects/movers/PathPlayerMover.h
@@ -2,6 +2,7 @@
 
 #ifndef PATHPLAYERMOVER_H
 #define PATHPLAYERMOVER_H
+#include <filesystem>
 #include "../Player.h"
 #include "../../pathing/Path.h"
 
@@ -17,7 +18,7 @@ public:
         player(player), path(path) {
         path = Path(
             player.GetPosition(),
-            "/Users/vladino/CLionProjects/mygame/resources/images/route.png",
+            std::filesystem::path("/Users/vladino/CLionProjects/mygame/resources/images/route.png"),
             terrainSize
         );
         // TODO: This may be NULL POINTER EXCEPTION

--- a/src/pathing/Path.cpp
+++ b/src/pathing/Path.cpp
@@ -10,7 +10,7 @@ float distance = 2.5;
 int raysPerIteration = 180;
 int seeks = 300;
 
-void Path::generatePath(glm::vec3 startPosition, const char* blendMap, int terrainSize) {
+void Path::generatePath(glm::vec3 startPosition, const std::filesystem::path& blendMap, int terrainSize) {
     path = {
         startPosition
     };

--- a/src/pathing/Path.h
+++ b/src/pathing/Path.h
@@ -2,6 +2,7 @@
 
 #ifndef PATHGENERATOR_H
 #define PATHGENERATOR_H
+#include <filesystem>
 #include "../terrain/Terrain.h"
 #include "glm/vec3.hpp"
 
@@ -9,11 +10,11 @@
 class Path {
 private:
     std::vector<glm::vec3> path;
-    void generatePath(glm::vec3 startPosition, const char* blendMap, int terrainSize);
+    void generatePath(glm::vec3 startPosition, const std::filesystem::path& blendMap, int terrainSize);
 public:
     explicit Path(
         const glm::vec3 startPosition,
-        const char *blendMap,
+        const std::filesystem::path& blendMap,
         const int terrainSize
     ) {
         generatePath(startPosition, blendMap, terrainSize);

--- a/src/shaders/shader.h
+++ b/src/shaders/shader.h
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
+#include <filesystem>
 #include <glm/gtc/type_ptr.hpp>
 
 class Shader
@@ -15,7 +16,7 @@ public:
     unsigned int ID;
     // constructor generates the shader on the fly
     // ------------------------------------------------------------------------
-    Shader(const char* vertexPath, const char* fragmentPath)
+    Shader(const std::filesystem::path& vertexPath, const std::filesystem::path& fragmentPath)
     {
         // 1. retrieve the vertex/fragment source code from filePath
         std::string vertexCode;

--- a/src/skybox/Skybox.cpp
+++ b/src/skybox/Skybox.cpp
@@ -5,6 +5,7 @@
 #include "../images/Image.h"
 #include "../models/ModelGenerator.h"
 #include "../textures/TextureLoader.h"
+#include <data_dir.h>
 
 using path = std::filesystem::path;
 
@@ -12,12 +13,12 @@ void Skybox::loadCubemap(const char* skyboxName) {
 
     // prepare faces
     std::vector<std::filesystem::path> faces;
-    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("left.png"));
-    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("right.png"));
-    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("top.png"));
-    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("bottom.png"));
-    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("front.png"));
-    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("back.png"));
+    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("left.png"));
+    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("right.png"));
+    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("top.png"));
+    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("bottom.png"));
+    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("front.png"));
+    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("back.png"));
 
     // Load cubemap texture
     glGenTextures(1, &cubemapTexture);

--- a/src/skybox/Skybox.cpp
+++ b/src/skybox/Skybox.cpp
@@ -6,23 +6,25 @@
 #include "../models/ModelGenerator.h"
 #include "../textures/TextureLoader.h"
 
+using path = std::filesystem::path;
+
 void Skybox::loadCubemap(const char* skyboxName) {
 
     // prepare faces
-    std::vector<std::string> faces;
-    faces.push_back("/Users/vladino/CLionProjects/mygame/resources/images/skybox/" + std::string(skyboxName) + "/left.png");
-    faces.push_back("/Users/vladino/CLionProjects/mygame/resources/images/skybox/" + std::string(skyboxName) + "/right.png");
-    faces.push_back("/Users/vladino/CLionProjects/mygame/resources/images/skybox/" + std::string(skyboxName) + "/top.png");
-    faces.push_back("/Users/vladino/CLionProjects/mygame/resources/images/skybox/" + std::string(skyboxName) + "/bottom.png");
-    faces.push_back("/Users/vladino/CLionProjects/mygame/resources/images/skybox/" + std::string(skyboxName) + "/front.png");
-    faces.push_back("/Users/vladino/CLionProjects/mygame/resources/images/skybox/" + std::string(skyboxName) + "/back.png");
+    std::vector<std::filesystem::path> faces;
+    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("left.png"));
+    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("right.png"));
+    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("top.png"));
+    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("bottom.png"));
+    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("front.png"));
+    faces.push_back(path("/Users/vladino/CLionProjects/mygame/resources/images/skybox") /= path(skyboxName) /= path("back.png"));
 
     // Load cubemap texture
     glGenTextures(1, &cubemapTexture);
     glBindTexture(GL_TEXTURE_CUBE_MAP, cubemapTexture);
 
     for (unsigned int i = 0; i < faces.size(); i++) {
-        auto image = Image(faces[i].c_str());
+        auto image = Image(faces[i]);
         glTexImage2D(
             GL_TEXTURE_CUBE_MAP_POSITIVE_X + i,
             0,

--- a/src/skybox/SkyboxRenderer.h
+++ b/src/skybox/SkyboxRenderer.h
@@ -6,6 +6,7 @@
 #include "Skybox.h"
 #include "../camera/camera.h"
 #include "../shaders/shader.h"
+#include <data_dir.h>
 
 
 class SkyboxRenderer {
@@ -15,8 +16,8 @@ private:
     Camera& camera;
 public:
     explicit SkyboxRenderer(Camera& camera) : shader(
-    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/skyboxShader.vs"),
-    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/skyboxShader.fs")
+    data_dir() /= path("src/shaders/files/skyboxShader.vs"),
+    data_dir() /= path("src/shaders/files/skyboxShader.fs")
     ), camera(camera) {}
     ~SkyboxRenderer() = default;
     const void render(Skybox& skybox);

--- a/src/skybox/SkyboxRenderer.h
+++ b/src/skybox/SkyboxRenderer.h
@@ -2,6 +2,7 @@
 
 #ifndef SKYBOXRENDERER_H
 #define SKYBOXRENDERER_H
+#include <filesystem>
 #include "Skybox.h"
 #include "../camera/camera.h"
 #include "../shaders/shader.h"
@@ -9,12 +10,13 @@
 
 class SkyboxRenderer {
 private:
+    using path = std::filesystem::path;
     Shader shader;
     Camera& camera;
 public:
     explicit SkyboxRenderer(Camera& camera) : shader(
-    "/Users/vladino/CLionProjects/mygame/src/shaders/files/skyboxShader.vs",
-    "/Users/vladino/CLionProjects/mygame/src/shaders/files/skyboxShader.fs"
+    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/skyboxShader.vs"),
+    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/skyboxShader.fs")
     ), camera(camera) {}
     ~SkyboxRenderer() = default;
     const void render(Skybox& skybox);

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -11,6 +11,7 @@
 #include "../shaders/shader.h"
 #include "../textures/TextureLoader.h"
 #include <glm/glm.hpp>
+#include <data_dir.h>
 
 using path = std::filesystem::path;
 
@@ -26,11 +27,11 @@ Terrain::Terrain(const std::filesystem::path& heightMap, const std::filesystem::
 }
 
 void Terrain::generateTextures() {
-    this->grassTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/green-grass4.png"));
-    this->pathTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/path.png"));
-    this->mudTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/mud.png"));
-    this->flowersTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/grassFlowers.png"));
-    this->blendMapTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/blendMap4.png"));
+    this->grassTexture = TextureLoader::loadTexture(data_dir() /= path("resources/images/green-grass4.png"));
+    this->pathTexture = TextureLoader::loadTexture(data_dir() /= path("resources/images/path.png"));
+    this->mudTexture = TextureLoader::loadTexture(data_dir() /= path("resources/images/mud.png"));
+    this->flowersTexture = TextureLoader::loadTexture(data_dir() /= path("resources/images/grassFlowers.png"));
+    this->blendMapTexture = TextureLoader::loadTexture(data_dir() /= path("resources/images/blendMap4.png"));
 }
 
 
@@ -53,7 +54,7 @@ void Terrain::generateVaoVbo() {
 
 void Terrain::generateGrasses() {
     std::cout << "Generating grasses" << std::endl;
-    Model* grass = ModelGenerator::generateGrass(path("/Users/vladino/CLionProjects/mygame/resources/objects/grass4/grass.png"));
+    Model* grass = ModelGenerator::generateGrass(data_dir() /= path("resources/objects/grass4/grass.png"));
 
     float density = 0.1;
     int perTileEntities = 10 * density;

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -12,7 +12,9 @@
 #include "../textures/TextureLoader.h"
 #include <glm/glm.hpp>
 
-Terrain::Terrain(char const* heightMap, char const* blendMap)
+using path = std::filesystem::path;
+
+Terrain::Terrain(const std::filesystem::path& heightMap, const std::filesystem::path& blendMap)
     : grasses(EntitiesHolder(std::vector<Entity>())) {
     dataPoints = new float[SIZE * SIZE * 30];
     parseHeightMap(heightMap);
@@ -24,11 +26,11 @@ Terrain::Terrain(char const* heightMap, char const* blendMap)
 }
 
 void Terrain::generateTextures() {
-    this->grassTexture = TextureLoader::loadTexture("/Users/vladino/CLionProjects/mygame/resources/images/green-grass4.png");
-    this->pathTexture = TextureLoader::loadTexture("/Users/vladino/CLionProjects/mygame/resources/images/path.png");
-    this->mudTexture = TextureLoader::loadTexture("/Users/vladino/CLionProjects/mygame/resources/images/mud.png");
-    this->flowersTexture = TextureLoader::loadTexture("/Users/vladino/CLionProjects/mygame/resources/images/grassFlowers.png");
-    this->blendMapTexture = TextureLoader::loadTexture("/Users/vladino/CLionProjects/mygame/resources/images/blendMap4.png");
+    this->grassTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/green-grass4.png"));
+    this->pathTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/path.png"));
+    this->mudTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/mud.png"));
+    this->flowersTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/grassFlowers.png"));
+    this->blendMapTexture = TextureLoader::loadTexture(path("/Users/vladino/CLionProjects/mygame/resources/images/blendMap4.png"));
 }
 
 
@@ -51,7 +53,7 @@ void Terrain::generateVaoVbo() {
 
 void Terrain::generateGrasses() {
     std::cout << "Generating grasses" << std::endl;
-    Model* grass = ModelGenerator::generateGrass("/Users/vladino/CLionProjects/mygame/resources/objects/grass4/grass.png");
+    Model* grass = ModelGenerator::generateGrass(path("/Users/vladino/CLionProjects/mygame/resources/objects/grass4/grass.png"));
 
     float density = 0.1;
     int perTileEntities = 10 * density;
@@ -121,11 +123,11 @@ glm::vec3 Terrain::calculateNormal(float x, float z) {
     return glm::normalize(normal);
 }
 
-void Terrain::parseHeightMap(char const* heightMap) {
+void Terrain::parseHeightMap(const std::filesystem::path& heightMap) {
     this->heightMap = new Image(heightMap);
 }
 
-void Terrain::parseBlendMap(char const *blendMap) {
+void Terrain::parseBlendMap(const std::filesystem::path& blendMap) {
     this->blendMap = new Image(blendMap);
 }
 

--- a/src/terrain/Terrain.h
+++ b/src/terrain/Terrain.h
@@ -1,5 +1,6 @@
 #ifndef TERRAIN_H
 #define TERRAIN_H
+#include <filesystem>
 #include "Grasses.h"
 #include "../images/Image.h"
 #include "../models/Model.h"
@@ -22,8 +23,8 @@ private:
     Image* heightMap;
     Image* blendMap;
 
-    void parseHeightMap(char const *heightMap);
-    void parseBlendMap(char const* blendMap);
+    void parseHeightMap(const std::filesystem::path& heightMap);
+    void parseBlendMap(const std::filesystem::path& blendMap);
     void generateTextures();
     void generateVaoVbo();
 
@@ -35,7 +36,7 @@ private:
     void generateGrasses();
 
 public:
-    Terrain(char const* heightMap, char const* blendMap);
+    Terrain(const std::filesystem::path& heightMap, const std::filesystem::path& blendMap);
     ~Terrain() = default;
     [[nodiscard]] const float* GetDataPoints() const;
     [[nodiscard]] const float GetCountOfVertices() const;

--- a/src/terrain/TerrainRenderer.cpp
+++ b/src/terrain/TerrainRenderer.cpp
@@ -1,11 +1,14 @@
 #include "TerrainRenderer.h"
 
+#include <filesystem>
 #include "../models/EntityRenderer.h"
+
+using path = std::filesystem::path;
 
 TerrainRenderer::TerrainRenderer(Camera* camera, EntityRenderer* modelRenderer) {
     this->shader = new Shader(
-    "/Users/vladino/CLionProjects/mygame/src/shaders/files/terrainShader.vs",
-    "/Users/vladino/CLionProjects/mygame/src/shaders/files/terrainShader.fs"
+    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/terrainShader.vs"),
+    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/terrainShader.fs")
     );
     this->camera = camera;
     this->entityRenderer = modelRenderer;

--- a/src/terrain/TerrainRenderer.cpp
+++ b/src/terrain/TerrainRenderer.cpp
@@ -2,13 +2,14 @@
 
 #include <filesystem>
 #include "../models/EntityRenderer.h"
+#include <data_dir.h>
 
 using path = std::filesystem::path;
 
 TerrainRenderer::TerrainRenderer(Camera* camera, EntityRenderer* modelRenderer) {
     this->shader = new Shader(
-    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/terrainShader.vs"),
-    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/terrainShader.fs")
+    data_dir() /= path("src/shaders/files/terrainShader.vs"),
+    data_dir() /= path("src/shaders/files/terrainShader.fs")
     );
     this->camera = camera;
     this->entityRenderer = modelRenderer;

--- a/src/text/TextRenderer.cpp
+++ b/src/text/TextRenderer.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 
 #include "glm/ext/matrix_clip_space.hpp"
+#include <data_dir.h>
 
 using path = std::filesystem::path;
 
@@ -19,15 +20,15 @@ unsigned int textVAO, textVBO;
 
 TextRenderer::TextRenderer(int screenWidth, int screenHeight) {
     shader = new Shader(
-    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/textShader.vs"),
-    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/textShader.fs")
+    data_dir() /= path("src/shaders/files/textShader.vs"),
+    data_dir() /= path("src/shaders/files/textShader.fs")
     );
     if (FT_Init_FreeType(&ft)) {
         std::cout << "ERROR::FREETYPE: Could not init FreeType Library" <<std::endl;
     }
     if (FT_New_Face(
         ft,
-        path("/Users/vladino/CLionProjects/mygame/resources/fonts/Arial.ttf").c_str(),
+        (data_dir() /= path("resources/fonts/Arial.ttf")).c_str(),
         0,
         &face)) {
         std::cout << "ERROR::FREETYPE: Failed to load font" << std::endl;

--- a/src/text/TextRenderer.cpp
+++ b/src/text/TextRenderer.cpp
@@ -2,8 +2,11 @@
 
 #include <map>
 #include <utility>
+#include <filesystem>
 
 #include "glm/ext/matrix_clip_space.hpp"
+
+using path = std::filesystem::path;
 
 struct Character {
     unsigned int TextureID; // ID handle of the glyph texture
@@ -16,15 +19,15 @@ unsigned int textVAO, textVBO;
 
 TextRenderer::TextRenderer(int screenWidth, int screenHeight) {
     shader = new Shader(
-    "/Users/vladino/CLionProjects/mygame/src/shaders/files/textShader.vs",
-    "/Users/vladino/CLionProjects/mygame/src/shaders/files/textShader.fs"
+    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/textShader.vs"),
+    path("/Users/vladino/CLionProjects/mygame/src/shaders/files/textShader.fs")
     );
     if (FT_Init_FreeType(&ft)) {
         std::cout << "ERROR::FREETYPE: Could not init FreeType Library" <<std::endl;
     }
     if (FT_New_Face(
         ft,
-        "/Users/vladino/CLionProjects/mygame/resources/fonts/Arial.ttf",
+        path("/Users/vladino/CLionProjects/mygame/resources/fonts/Arial.ttf").c_str(),
         0,
         &face)) {
         std::cout << "ERROR::FREETYPE: Failed to load font" << std::endl;

--- a/src/textures/TextureLoader.h
+++ b/src/textures/TextureLoader.h
@@ -4,13 +4,14 @@
 #include <glad/glad.h>
 #include <stb_image.h>
 #include <iostream>
+#include <filesystem>
 
 class TextureLoader {
 public:
-    static unsigned int loadTexture(char const* value) {
+    static unsigned int loadTexture(const std::filesystem::path& value) {
         std::cout << "Loading texture: " << value << std::endl;
         int width, height, nrChannels;
-        unsigned char *data = stbi_load(value, &width, &height,
+        unsigned char *data = stbi_load(value.c_str(), &width, &height,
         &nrChannels, 0);
 
         GLenum format;


### PR DESCRIPTION
Paths to shaders and other resources are now relative to a 'data_dir', and this directory is set at compile time to the top-level project source directory, making this change backward compatible.

Closes #1 