### PR TITLE
Fix mesh triangle identification

### DIFF
--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -150,9 +150,9 @@ const float Terrain::GetHeightOfTerrain(float playerPositionX, float playerPosit
     auto d = glm::vec3(playerPositionXInt, getHeight(playerPositionXInt, playerPositionZInt - 1.0f), playerPositionZInt - 1.0f);
 
     float playerPositionXIntNormalized = playerPositionX - playerPositionXInt;
-    float playerPositionZIntNormalized = abs(playerPositionZ - playerPositionZInt);
+    float playerPositionZIntNormalized = playerPositionZ - playerPositionZInt;
 
-    if (playerPositionXIntNormalized < 1 - playerPositionZIntNormalized) {
+    if (-playerPositionZIntNormalized < playerPositionXIntNormalized) {
         // we are in the first triangle (C,A,B)
         return barryCentric(
             c, a, b,


### PR DESCRIPTION
Use correct mesh 'square' coordinates and criterion for determining which of the two mesh triangles of the 'square' a terrain position falls into.

Closes #12 