### PR TITLE
Reduce the number of useless object copies

### DIFF
--- a/src/fps/Fps.h
+++ b/src/fps/Fps.h
@@ -14,7 +14,7 @@ public:
     ~Fps() = default;
     void tick();
     float getFps() const { return fps; }
-    std::string getFpsAsString() const { return fpsAsString; }
+    const std::string& getFpsAsString() const { return fpsAsString; }
 };
 
 

--- a/src/models/EntityRenderer.cpp
+++ b/src/models/EntityRenderer.cpp
@@ -61,7 +61,7 @@ void EntityRenderer::renderBatch(const EntitiesHolder& modelsHolder) {
     // activate textures
     // const std::shared_ptr<Model> firstModel = modelsHolder.GetEntities()[0].GetModel();
     const std::shared_ptr<Model> firstModel = modelsHolder.GetEntities().front().GetModel();
-    Mesh firstMesh = firstModel->GetMeshes().front();
+    const Mesh& firstMesh = firstModel->GetMeshes().front();
     firstMesh.activateTextures(multiInstanceShader);
 
     // TODO: create sun class and move it there

--- a/src/models/Mesh.cpp
+++ b/src/models/Mesh.cpp
@@ -2,11 +2,8 @@
 
 #include "Mesh.h"
 
-Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std::vector<Texture> textures) {
-    this->vertices = vertices;
-    this->indices = indices;
-    this->textures = textures;
-
+Mesh::Mesh(std::vector<Vertex>&& vertices, std::vector<unsigned int>&& indices, std::vector<Texture>&& textures)
+: vertices(std::move(vertices)), indices(std::move(indices)), textures(std::move(textures)) {
     setupMesh();
 }
 

--- a/src/models/Mesh.h
+++ b/src/models/Mesh.h
@@ -22,7 +22,7 @@ struct Texture {
 
 class Mesh {
 public:
-    Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, std::vector<Texture> textures);
+    Mesh(std::vector<Vertex>&& vertices, std::vector<unsigned int>&& indices, std::vector<Texture>&& textures);
 
     void Draw(Shader& shader) const;
     void activateTextures(Shader& shader) const;

--- a/src/models/Model.h
+++ b/src/models/Model.h
@@ -15,7 +15,7 @@ public:
     explicit Model(const std::filesystem::path& modelPath);
     Model(const std::filesystem::path& modelPath, const std::filesystem::path& texturePath);
     Model(const std::filesystem::path& modelPath, Texture& texture);
-    explicit Model(Mesh &mesh);
+    explicit Model(Mesh&& mesh);
 
     void Draw(Shader& shader) const;
 
@@ -28,7 +28,7 @@ private:
     void loadModel(const std::filesystem::path& path);
     void processNode(aiNode *node, const aiScene *scene);
     Mesh processMesh(aiMesh *mesh, const aiScene *scene);
-    std::vector<Texture> loadMaterialTextures(aiMaterial *mat, aiTextureType type, std::string typeName);
+    void loadMaterialTextures(aiMaterial *mat, aiTextureType type, const std::string& typeName, std::vector<Texture>& textures);
     void loadSingleTexture(const std::filesystem::path& texturePath);
     void loadSingleTexture(Texture& texture);
 };

--- a/src/models/ModelGenerator.cpp
+++ b/src/models/ModelGenerator.cpp
@@ -39,50 +39,44 @@ std::shared_ptr<Model> ModelGenerator::generateCube(const std::filesystem::path&
    0.5f,  0.5f,  0.5f,  0.0f,  1.0f,  0.0f,  1.0f,  0.0f,
   -0.5f,  0.5f,  0.5f,  0.0f,  1.0f,  0.0f,  0.0f,  0.0f
 };
-
- // Indices for a cube
- unsigned int indices[] = {
-  // back face
-  0, 1, 2,
-  2, 3, 0,
-  // front face
-  4, 5, 6,
-  6, 7, 4,
-  // left face
-  8, 9, 10,
-  10, 11, 8,
-  // right face
-  12, 13, 14,
-  14, 15, 12,
-  // bottom face
-  16, 17, 18,
-  18, 19, 16,
-  // top face
-  20, 21, 22,
-  22, 23, 20
-};
    std::vector<Vertex> vectorVertices;
    for (int i = 0; i < 192; i += 8) {
-       Vertex vertex;
-       vertex.Position = glm::vec3(vertices[i], vertices[i + 1], vertices[i + 2]);
-       vertex.Normal = glm::vec3(vertices[i + 3], vertices[i + 4], vertices[i + 5]);
-       vertex.TexCoords = glm::vec2(vertices[i + 6], vertices[i + 7]);
-       vectorVertices.push_back(vertex);
+       vectorVertices.push_back(Vertex{ glm::vec3{ vertices[i], vertices[i + 1], vertices[i + 2] },
+                                        glm::vec3{ vertices[i + 3], vertices[i + 4], vertices[i + 5] },
+                                        glm::vec2{ vertices[i + 6], vertices[i + 7] } });
    }
-    std::vector<unsigned int> vectorIndices;
-    for (int i = 0; i < 36; i++) {
-     vectorIndices.push_back(indices[i]);
-    }
-    std::vector<Texture> vectorTextures;
-    Texture texture;
-    texture.id = TextureLoader::loadTexture(texturePath);
-    texture.type = "texture_diffuse";
-    texture.path = texturePath;
-    vectorTextures.push_back(texture);
 
-   Mesh mesh(vectorVertices, vectorIndices, vectorTextures);
-
-   return std::make_shared<Model>(mesh);
+   return std::make_shared<Model>(
+       Mesh{ std::move(vectorVertices),
+             // Indices for a cube
+             {
+                 // back face
+                 0, 1, 2,
+                 2, 3, 0,
+                 // front face
+                 4, 5, 6,
+                 6, 7, 4,
+                 // left face
+                 8, 9, 10,
+                 10, 11, 8,
+                 // right face
+                 12, 13, 14,
+                 14, 15, 12,
+                 // bottom face
+                 16, 17, 18,
+                 18, 19, 16,
+                 // top face
+                 20, 21, 22,
+                 22, 23, 20
+             },
+             {
+                 {
+                     TextureLoader::loadTexture(texturePath),
+                     "texture_diffuse",
+                     texturePath
+                 }
+             }
+       } );
 }
 
 std::shared_ptr<Model> ModelGenerator::generateGrass(const std::filesystem::path& texturePath) {
@@ -94,34 +88,27 @@ std::shared_ptr<Model> ModelGenerator::generateGrass(const std::filesystem::path
   -0.5f,  0.5f, -0.5f,  0.0f,  0.0f, -1.0f,  0.0f,  1.0f,
 };
 
- // Indices for a cube
- unsigned int indices[] = {
-   // back face
-   0, 1, 2,
-   2, 3, 0
- };
-
  std::vector<Vertex> vectorVertices;
  for (int i = 0; i < 8 * 4; i += 8) {
-  Vertex vertex;
-  vertex.Position = glm::vec3(vertices[i], vertices[i + 1], vertices[i + 2]);
-  vertex.Normal = glm::vec3(vertices[i + 3], vertices[i + 4], vertices[i + 5]);
-  vertex.TexCoords = glm::vec2(vertices[i + 6], vertices[i + 7]);
-  vectorVertices.push_back(vertex);
- }
- std::vector<unsigned int> vectorIndices;
- for (int i = 0; i < 6; i++) {
-  vectorIndices.push_back(indices[i]);
+     vectorVertices.push_back(Vertex{ glm::vec3{ vertices[i], vertices[i + 1], vertices[i + 2] },
+                                      glm::vec3{ vertices[i + 3], vertices[i + 4], vertices[i + 5] },
+                                      glm::vec2{ vertices[i + 6], vertices[i + 7] } });
  }
 
- std::vector<Texture> vectorTextures;
- Texture texture;
- texture.id = TextureLoader::loadTexture(texturePath);
- texture.type = "texture_diffuse";
- texture.path = texturePath;
- vectorTextures.push_back(texture);
-
- Mesh mesh(vectorVertices, vectorIndices, vectorTextures);
-
- return std::make_shared<Model>(mesh);
+ return std::make_shared<Model>(
+     Mesh{ std::move(vectorVertices),
+           // Indices for a cube
+           {
+               // back face
+               0, 1, 2,
+               2, 3, 0
+           },
+           {
+               {
+                   TextureLoader::loadTexture(texturePath),
+                   "texture_diffuse",
+                   texturePath
+               }
+           }
+     } );
 }

--- a/src/skybox/Skybox.cpp
+++ b/src/skybox/Skybox.cpp
@@ -13,12 +13,12 @@ void Skybox::loadCubemap(const char* skyboxName) {
 
     // prepare faces
     std::vector<std::filesystem::path> faces;
-    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("left.png"));
-    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("right.png"));
-    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("top.png"));
-    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("bottom.png"));
-    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("front.png"));
-    faces.push_back(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("back.png"));
+    faces.push_back(std::move(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("left.png")));
+    faces.push_back(std::move(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("right.png")));
+    faces.push_back(std::move(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("top.png")));
+    faces.push_back(std::move(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("bottom.png")));
+    faces.push_back(std::move(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("front.png")));
+    faces.push_back(std::move(data_dir() /= path("resources/images/skybox") /= path(skyboxName) /= path("back.png")));
 
     // Load cubemap texture
     glGenTextures(1, &cubemapTexture);

--- a/src/terrain/EntitiesHolder.h
+++ b/src/terrain/EntitiesHolder.h
@@ -7,7 +7,7 @@
 
 class EntitiesHolder {
 public:
-    EntitiesHolder(std::vector<Entity> entities): entities(std::move(entities)) {}
+    EntitiesHolder(std::vector<Entity>&& entities): entities(std::move(entities)) {}
     ~EntitiesHolder() = default;
     [[nodiscard]] const std::vector<Entity>& GetEntities() const { return entities; }
 private:

--- a/src/terrain/Grasses.cpp
+++ b/src/terrain/Grasses.cpp
@@ -8,7 +8,7 @@
 #include "../objects/Entity.h"
 
 void Grasses::prepare() {
-    std::vector<Entity> entities = grasses.GetEntities();
+    const std::vector<Entity>& entities = grasses.GetEntities();
     if (entities.empty()) {
         return;
     }

--- a/src/terrain/Grasses.h
+++ b/src/terrain/Grasses.h
@@ -10,7 +10,7 @@ private:
     EntitiesHolder grasses;
     void prepare();
 public:
-    explicit Grasses(const EntitiesHolder& grasses) : grasses(grasses) {
+    explicit Grasses(EntitiesHolder&& grasses) : grasses(std::move(grasses)) {
         this->prepare();
     }
     [[nodiscard]] const EntitiesHolder& GetEntities() const {return grasses;}

--- a/src/terrain/Terrain.cpp
+++ b/src/terrain/Terrain.cpp
@@ -90,8 +90,8 @@ void Terrain::generateGrasses() {
         }
     }
 
-    this->grasses = Grasses{EntitiesHolder{entities}};
     Log::logInfo("Generated grasses: " + std::to_string(entities.size()));
+    this->grasses = Grasses{EntitiesHolder{std::move(entities)}};
 }
 
 const float Terrain::getHeight(float x, float z) const {


### PR DESCRIPTION
Use references and move assignment/construction to reduce the number of times objects are copied around.

The object copies addressed here do not include the needless copy of issue #16 .

Closes #17 .