### PR TITLE
Improve player motion along the path

### DIFF
--- a/src/objects/Player.cpp
+++ b/src/objects/Player.cpp
@@ -76,18 +76,8 @@ void Player::MoveBy(const glm::vec3& moveVector) {
 /**
  * Moves player in given direction by given distance.
  */
-void Player::MoveIn(const glm::vec3& dir, float distance) {
-    float dirLengthSquared = dir.x * dir.x + dir.y * dir.y + dir.z * dir.z;
-    if (dirLengthSquared > 0.0001f) { // Avoid division by zero or moving in zero direction
-        glm::vec3 normalizedDir = glm::normalize(dir);
-
-        // Clamp distance to prevent large movements due to high deltaTime
-        float maxDistance = 1.0f; // Adjust as needed
-        distance = glm::min(distance, maxDistance);
-
-        glm::vec3 movement = normalizedDir * distance;
-        MoveBy(movement);
-    }
+void Player::MoveIn(const glm::vec3& normalizedDir, float distance) {
+    MoveBy(normalizedDir * distance);
 }
 
 void Player::Jump() {

--- a/src/objects/Player.cpp
+++ b/src/objects/Player.cpp
@@ -60,7 +60,7 @@ void Player::UpdateCameraYaw(bool animated) {
  *
  * It also updates camera position, pitch and yaw to match the new player position.
  */
-void Player::MoveBy(glm::vec3& moveVector) {
+void Player::MoveBy(const glm::vec3& moveVector) {
     // we first move entity
     Entity::MoveBy(moveVector);
 
@@ -76,7 +76,7 @@ void Player::MoveBy(glm::vec3& moveVector) {
 /**
  * Moves player in given direction by given distance.
  */
-void Player::MoveIn(const glm::vec3& dir, float& distance) {
+void Player::MoveIn(const glm::vec3& dir, float distance) {
     float dirLengthSquared = dir.x * dir.x + dir.y * dir.y + dir.z * dir.z;
     if (dirLengthSquared > 0.0001f) { // Avoid division by zero or moving in zero direction
         glm::vec3 normalizedDir = glm::normalize(dir);

--- a/src/objects/Player.h
+++ b/src/objects/Player.h
@@ -47,8 +47,8 @@ public:
     Player(Camera &camera, Terrain &terrain, const std::shared_ptr<Model> &model, glm::vec3 position):
         Entity(model, position), terrain(terrain), camera(camera) {
     }
-    void MoveBy(glm::vec3& moveVector);
-    void MoveIn(const glm::vec3& dir, float& distance);
+    void MoveBy(const glm::vec3& moveVector);
+    void MoveIn(const glm::vec3& dir, float distance);
 
     void UpdateCameraPosition(bool animated = true);
 

--- a/src/objects/movers/PathPlayerMover.h
+++ b/src/objects/movers/PathPlayerMover.h
@@ -34,7 +34,7 @@ public:
         movingTowards = path.getPath().at(1);
         setToStart();
     }
-    void move(float deltaTime);
+    void move(float distance);
 };
 
 


### PR DESCRIPTION
This partially addresses issue #23 . It improves the player's motion between waypoints, the first point in #23's description, but still only on the x-z plane.  It does not account for the distance traveled on the 3-D surface.